### PR TITLE
Add .env.example file with required environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+PORT=8080
+AUTH0_DOMAIN=<auth0_domain>
+AUTH0_CLIENT_ID=<auth0_client_id>
+AUTH0_CLIENT_SECRET=<auth0_client_secret>
+AUTH0_CALLBACK_URL=http://localhost:8080/callback

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,3 +9,13 @@ mentor-matcher: $(GO_SRC)
 .PHONY: clean
 clean:
 	@rm -f mentor-matcher
+
+.PHONY: docker-up
+docker-up:
+	docker-compose build
+	docker-compose up -d
+
+.PHONY: docker-down
+docker-down:
+	docker-compose down
+

--- a/README.md
+++ b/README.md
@@ -2,3 +2,29 @@
 A website for mentees to find mentors and mentors to offer their wisdom to others
 
 https://mentor-matcher.fly.dev/
+
+## Local Installation
+
+This project uses GNU Make to automate the setup process. Ensure that you have a `.env` file in the 
+root directory of the project. See `.env.example` for an example of the required environment 
+variables.
+
+To build the binaries, run the following command:
+
+```bash
+make
+```
+
+Alternatively, you can use Docker compose to run the project locally. You'll still need the `.env` 
+file. To do so, run the following command:
+
+```bash
+make docker-up
+```
+
+To stop the Docker containers, run the following command:
+
+```bash
+make docker-down
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env


### PR DESCRIPTION
Added instructions on how to set up locally and documented the `.env` file requirements so far.