### PR TITLE
Add healthcheck endpoint to router

### DIFF
--- a/platform/router/router.go
+++ b/platform/router/router.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/willprice/mentor-matcher/platform/authenticator"
 	"github.com/willprice/mentor-matcher/platform/middleware"
-	"github.com/willprice/mentor-matcher/web/app/callback"
+	"github.com/willprice/mentor-matcher/web/app/callback"	
+	"github.com/willprice/mentor-matcher/web/app/healthcheck"
 	"github.com/willprice/mentor-matcher/web/app/home"
 	"github.com/willprice/mentor-matcher/web/app/login"
 	"github.com/willprice/mentor-matcher/web/app/logout"
@@ -35,6 +36,7 @@ func New(auth *authenticator.Authenticator) *gin.Engine {
 	router.GET("/callback", callback.Handler(auth))
 	router.GET("/user", middleware.IsAuthenticated, user.Handler)
 	router.GET("/logout", logout.Handler)
+	router.GET("/healthcheck", healthcheck.Handler)
 
 	return router
 }

--- a/web/app/healthcheck/healthcheck.go
+++ b/web/app/healthcheck/healthcheck.go
@@ -1,0 +1,12 @@
+package healthcheck
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler for the healthcheck.
+func Handler(ctx *gin.Context) {
+	ctx.String(http.StatusOK, "OK")
+}

--- a/web/app/healthcheck/healthcheck_test.go
+++ b/web/app/healthcheck/healthcheck_test.go
@@ -1,0 +1,28 @@
+package healthcheck
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestHandler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	ctx, _ := gin.CreateTestContext(w)
+
+	Handler(ctx)
+
+	// Check if the status code is 200.
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, but got %d", http.StatusOK, w.Code)
+	}
+
+	// Check if the response body is "OK".
+	expectedBody := "OK"
+	if w.Body.String() != expectedBody {
+		t.Errorf("Expected body '%s', but got '%s'", expectedBody, w.Body.String())
+	}
+}


### PR DESCRIPTION
Add a simple healthcheck endpoint to the app to track when the server is able to receive HTTP requests.