### PR TITLE
Fix incorrect transport scheme when logging out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@ AUTH0_DOMAIN=<auth0_domain>
 AUTH0_CLIENT_ID=<auth0_client_id>
 AUTH0_CLIENT_SECRET=<auth0_client_secret>
 AUTH0_CALLBACK_URL=http://localhost:8080/callback
+
+# Valid values:
+# - http: for local deployments without TLS termination
+# - https: for deployments with TLS termination
+TRANSPORT_SCHEME=http

--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,7 @@ primary_region = 'lhr'
 
 [env]
   PORT = '8080'
+  TRANSPORT_SCHEME = 'https'
 
 [http_service]
   internal_port = 8080

--- a/web/app/logout/logout.go
+++ b/web/app/logout/logout.go
@@ -16,9 +16,9 @@ func Handler(ctx *gin.Context) {
 		return
 	}
 
-	scheme := "http"
-	if ctx.Request.TLS != nil {
-		scheme = "https"
+	scheme := os.Getenv("TRANSPORT_SCHEME")
+	if scheme == "" {
+		scheme = "http"
 	}
 
 	returnTo, err := url.Parse(scheme + "://" + ctx.Request.Host)


### PR DESCRIPTION
*Before:* When a user logs out the generated `redirectTo` parameter in the redirect URL used the transport scheme of the webserver. This is instead of using the transport scheme of the deployment. This would cause issues when the application is deployed behind a TLS terminating load balancer as the user would communicate using https but the web server would use http to communicate with the load balancer.

*After:* The transport scheme of the `redirectTo` redirect URL parameter can be configured using the `TRANSPORT_SCHEME` environment variable. (defaulting to `http`). This allows the operator to specify the transport scheme that will be used to communicate between the user and the deployment edge.